### PR TITLE
update zenburn-ligh-putty.reg: fix space encoding

### DIFF
--- a/zenburn-ligh-putty.reg
+++ b/zenburn-ligh-putty.reg
@@ -1,6 +1,6 @@
 Windows Registry Editor Version 5.00
 
-[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Zenburn Light]
+[HKEY_CURRENT_USER\Software\SimonTatham\PuTTY\Sessions\Zenburn%20Light]
 "Colour0"="220,220,204"
 "Colour1"="220,220,204"
 "Colour2"="58,58,58"


### PR DESCRIPTION
Session with literal space in key name value cannot be deleted from PuTTY Configuration panel. Change literal space to '%20' to allow for deletion from config panel.
